### PR TITLE
feat(invoice): génération & consultation des factures mensuelles

### DIFF
--- a/prisma/migrations/20250720180629_invoice_aggregate/migration.sql
+++ b/prisma/migrations/20250720180629_invoice_aggregate/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `subscriptionId` on the `Invoice` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[userId,month]` on the table `Invoice` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Invoice" DROP CONSTRAINT "Invoice_subscriptionId_fkey";
+
+-- DropIndex
+DROP INDEX "Invoice_subscriptionId_key";
+
+-- AlterTable
+ALTER TABLE "Invoice" DROP COLUMN "subscriptionId",
+ADD COLUMN     "lines" JSONB;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Invoice_userId_month_key" ON "Invoice"("userId", "month");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,24 +84,20 @@ model Subscription {
   endDate   DateTime
   status    SubscriptionStatus @default(ACTIVE)
   remaining Int
-  invoice   Invoice?
 }
 
 model Invoice {
-  id             String        @id @default(uuid())
-  userId         String
-  subscriptionId String?       @unique   // ← ajoute @unique
-
-  user           User          @relation(fields: [userId], references: [id])
-  subscription   Subscription? @relation(fields: [subscriptionId], references: [id])
-
-  month   DateTime
-  amount  Decimal  @db.Decimal(10,2)
-  pdfUrl  String?
+  id     String @id @default(uuid())
+  userId String
+  user   User   @relation(fields: [userId], references: [id])
+  month     DateTime
+  amount    Decimal  @db.Decimal(10, 2)
+  lines     Json?
+  pdfUrl    String?
   createdAt DateTime @default(now())
+
+  @@unique([userId, month])
 }
-
-
 
 model MonitoredNumber {
   id        String   @id @default(uuid())

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { OffersModule } from './offers/offers.module';
 import { PhonesModule } from './phones/phones.module';
 import { SubscriptionsModule } from './subscriptions/subscriptions.module';
 import { MonitoredModule } from './monitored/monitored.module';
+import { InvoicesModule } from './invoices/invoices.module';
 
 
 
@@ -39,7 +40,8 @@ import { MonitoredModule } from './monitored/monitored.module';
     OffersModule,
     PhonesModule,
     SubscriptionsModule,
-    MonitoredModule,],
+    MonitoredModule,
+    InvoicesModule,],
   providers: [],
 })
 export class AppModule { }

--- a/src/invoices/invoices.controller.ts
+++ b/src/invoices/invoices.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { InvoicesService } from './invoices.service';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth-guard';
+import { CurrentUser } from 'src/auth/current-user-decorator';
+import { TokenPayload } from 'src/auth/token-payload-interface';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiParam, ApiQuery } from '@nestjs/swagger';
+
+@ApiTags('invoices')
+@ApiBearerAuth('Authorization')
+@UseGuards(JwtAuthGuard)
+@Controller('invoices')
+export class InvoicesController {
+  constructor(private svc: InvoicesService) {}
+
+  @ApiOperation({ summary: 'Lister mes factures' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'year', required: false, type: Number })
+  @Get()
+  list(
+    @CurrentUser() me: TokenPayload,
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+    @Query('year') year?: number,
+  ) {
+    return this.svc.list(me.userId, Number(page), Number(limit), Number(year));
+  }
+
+  @ApiOperation({ summary: `Détail d'une facture` })
+  @ApiParam({ name: 'id', description: 'ID de la facture' })
+  @Get(':id')
+  getOne(@CurrentUser() me: TokenPayload, @Param('id') id: string) {
+    return this.svc.getOne(me.userId, id);
+  }
+}

--- a/src/invoices/invoices.module.ts
+++ b/src/invoices/invoices.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { InvoicesController } from './invoices.controller';
+import { InvoicesService } from './invoices.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [InvoicesService],
+  controllers: [InvoicesController]
+})
+export class InvoicesModule {}

--- a/src/invoices/invoices.service.ts
+++ b/src/invoices/invoices.service.ts
@@ -1,0 +1,35 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class InvoicesService {
+    constructor(private prisma: PrismaService) { }
+
+    /** Liste paginée des factures de l’utilisateur */
+    list(userId: string, page = 1, limit = 20, year?: number) {
+        const take = Math.min(Math.max(limit, 5), 50);
+        const where = {
+            userId,
+            ...(year ? { month: { gte: new Date(`${year}-01-01`), lt: new Date(`${year + 1}-01-01`) } } : {}),
+        };
+
+        return this.prisma.invoice.findMany({
+            where,
+            orderBy: { month: 'desc' },
+            skip: (page - 1) * take,
+            take,
+            include: {
+                user: { select: { firstName: true, lastName: true, email: true } },
+            }
+        });
+    }
+
+    /** Détail d’une facture (JSON) */
+    async getOne(userId: string, id: string) {
+        const invoice = await this.prisma.invoice.findFirst({
+            where: { id, userId },
+        });
+        if (!invoice) throw new NotFoundException('Facture introuvable');
+        return invoice;
+    }
+}

--- a/src/offers/dto/subscribe.dto.ts
+++ b/src/offers/dto/subscribe.dto.ts
@@ -1,5 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsUUID } from 'class-validator';
 
 export class SubscribeDto {
-  @IsUUID() phoneId: string;
+  @ApiProperty({
+    description: `ID du numéro (phoneId) que l’utilisateur veut utiliser`,
+    example: 'f51cc6bd-d52a-4e09-81e7-338a5fb5963d',
+  })
+  @IsUUID()
+  phoneId!: string;
 }


### PR DESCRIPTION
 Création automatique / mise à jour de la facture json lors d’une souscription
- Ajout du champ `lines` (jsonb) pour le détail des achats (phone, offer, price)
- Endpoints protégés :
  GET /invoices           : liste paginée (page/limit/year)
  GET /invoices/:id        : détail complet d’une facture
- Swagger mis à jour avec le schéma complet (lines, amount, month, …)